### PR TITLE
feat: improve the Makefile to build dist using folders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+__Warning:__ This is a __WIP__
+
 `idp-scim-sync` is [Apache 2.0 licensed](https://github.com/slashdevops/idp-scim-sync/blob/main/LICENSE) and
 accepts contributions via GitHub pull requests. This document outlines
 some of the conventions on to make it easier to get your contribution
@@ -63,8 +65,8 @@ For better integration I use [go:generate](https://pkg.go.dev/cmd/go/internal/ge
 
 Prerequisites:
 
-- make >= 3
-- go >= 1.17
+- [make](https://www.gnu.org/software/make/) >= 3
+- [Go](https://go.dev/learn/) >= 1.17
 
 ```bash
 make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,24 @@ FROM ${ARCH}/alpine
 
 ARG OS="linux"
 ARG BIN_ARCH="amd64"
+
+ENV PROJECT_NAME="idp-scim-sync"
 ENV HOME="/app"
 
-LABEL name="idp-scim-sync"
+LABEL name="${PROJECT_NAME}"
 
 RUN apk add --no-cache --update \
-    ca-certificates \
-    && rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
+  ca-certificates \
+  && rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
 
 RUN mkdir -p $HOME && \
-    chown -R nobody.nobody $HOME
+  chown -R nobody.nobody $HOME
 
-COPY dist/idpscim-${OS}-${BIN_ARCH} ${HOME}/idpscim
-COPY dist/idpscimcli-${OS}-${BIN_ARCH} ${HOME}/idpscimcli
+COPY dist/$PROJECT_NAME-$OS-$BIN_ARCH/* $HOME/
 
 ENV PATH="${PATH}:${HOME}"
 
-VOLUME ${HOME}
+VOLUME $HOME
 USER nobody:nobody
 WORKDIR $HOME
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ build-dist: build
 	$(foreach GOOS, $(GO_OS),\
 		$(foreach GOARCH, $(GO_ARCH), \
 			$(foreach proj_mod, $(PROJECT_MODULES_NAME), \
-				$(shell GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(GO_CGO_ENABLED) go build $(GO_LDFLAGS) $(GO_OPTS) -o ./$(DIST_DIR)/$(proj_mod)-$(GOOS)-$(GOARCH) ./cmd/$(proj_mod)/ ))))
+				$(shell GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(GO_CGO_ENABLED) go build $(GO_LDFLAGS) $(GO_OPTS) -o ./$(DIST_DIR)/$(PROJECT_NAME)-$(GOOS)-$(GOARCH)/$(proj_mod) ./cmd/$(proj_mod)/ ))))
 
 clean:
 	rm -rf $(BUILD_DIR) $(DIST_DIR) ./*.out .aws-sam/ build.toml

--- a/docs/idpscim.md
+++ b/docs/idpscim.md
@@ -52,3 +52,15 @@ This could be used following the instructions in the main [README.md](docs/READM
 
 this is a __WIP__
 
+Test and build the Docker image
+
+```bash
+make test
+make container-build
+```
+
+Execute
+
+```bash
+docker run -it -v $HOME/tmp/idpscim.yaml:/app/.idpscim.yaml ghcr.io/slashdevops/idp-scim-sync-linux-arm64v8 idpscim --debug
+```

--- a/docs/idpscimcli.md
+++ b/docs/idpscimcli.md
@@ -77,3 +77,20 @@ then the binaries are in `dist/` folder.
 ```bash
 ./idpscimcli --help
 ```
+
+## Using the Docker image
+
+this is a __WIP__
+
+Test and build the Docker image
+
+```bash
+make test
+make container-build
+```
+
+Execute
+
+```bash
+docker run -it -v $HOME/tmp/idpscim.yaml:/app/.idpscim.yaml ghcr.io/slashdevops/idp-scim-sync-linux-arm64v8 idpscimcli --debug
+```


### PR DESCRIPTION
`Makefile`  command `make build-dist ` now creates directories inside the `./dist` for each combination of `OS `and `ARCH` and the binaries are inside of them.