### PR TITLE
fix: env variables name for secrets

### DIFF
--- a/cmd/idpscim/cmd/root.go
+++ b/cmd/idpscim/cmd/root.go
@@ -100,14 +100,14 @@ func initConfig() {
 		"aws_s3_bucket_key",
 		"gws_user_email",
 		"gws_service_account_file",
-		"gws_service_account_file_secret_arn",
-		"gws_user_email_secret_arn",
+		"gws_service_account_file_secret_name",
+		"gws_user_email_secret_name",
 		"gws_groups_filter",
 		"gws_users_filter",
 		"aws_scim_access_token",
 		"aws_scim_endpoint",
-		"aws_scim_endpoint_secret_arn",
-		"aws_scim_access_token_secret_arn",
+		"aws_scim_endpoint_secret_name",
+		"aws_scim_access_token_secret_name",
 		"disable_state",
 	}
 	for _, e := range envVars {
@@ -193,29 +193,29 @@ func getSecrets() {
 		log.Fatalf(errors.Wrap(err, "cannot create aws secrets manager service").Error())
 	}
 
-	log.WithField("name", cfg.GWSUserEmailSecretARN).Debug("reading secret")
-	unwrap, err := secrets.GetSecretValue(context.Background(), cfg.GWSUserEmailSecretARN)
+	log.WithField("name", cfg.GWSUserEmailSecretName).Debug("reading secret")
+	unwrap, err := secrets.GetSecretValue(context.Background(), cfg.GWSUserEmailSecretName)
 	if err != nil {
 		log.Fatalf(errors.Wrap(err, "cannot get secretmanager value").Error())
 	}
 	cfg.GWSUserEmail = unwrap
 
-	log.WithField("name", cfg.GWSServiceAccountFileSecretARN).Debug("reading secret")
-	unwrap, err = secrets.GetSecretValue(context.Background(), cfg.GWSServiceAccountFileSecretARN)
+	log.WithField("name", cfg.GWSServiceAccountFileSecretName).Debug("reading secret")
+	unwrap, err = secrets.GetSecretValue(context.Background(), cfg.GWSServiceAccountFileSecretName)
 	if err != nil {
 		log.Fatalf(errors.Wrap(err, "cannot get secretmanager value").Error())
 	}
 	cfg.GWSServiceAccountFile = unwrap
 
-	log.WithField("name", cfg.AWSSCIMAccessTokenSecretARN).Debug("reading secret")
-	unwrap, err = secrets.GetSecretValue(context.Background(), cfg.AWSSCIMAccessTokenSecretARN)
+	log.WithField("name", cfg.AWSSCIMAccessTokenSecretName).Debug("reading secret")
+	unwrap, err = secrets.GetSecretValue(context.Background(), cfg.AWSSCIMAccessTokenSecretName)
 	if err != nil {
 		log.Fatalf(errors.Wrap(err, "cannot get secretmanager value").Error())
 	}
 	cfg.AWSSCIMAccessToken = unwrap
 
-	log.WithField("name", cfg.AWSSCIMEndpointSecretARN).Debug("reading secret")
-	unwrap, err = secrets.GetSecretValue(context.Background(), cfg.AWSSCIMEndpointSecretARN)
+	log.WithField("name", cfg.AWSSCIMEndpointSecretName).Debug("reading secret")
+	unwrap, err = secrets.GetSecretValue(context.Background(), cfg.AWSSCIMEndpointSecretName)
 	if err != nil {
 		log.Fatalf(errors.Wrap(err, "cannot get secretmanager value").Error())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,18 @@ const (
 
 	// DefaultConfigFile is the default config file name.
 	DefaultConfigFile = ".idpscim.yaml"
+
+	// DefaultGWSServiceAccountFileSecretName is the name of the secret containing the service account credentials.
+	DefaultGWSServiceAccountFileSecretName = "IDPSCIM_GWSServiceAccountFile"
+
+	// DefaultGWSUserEmailSecretName is the name of the secret containing the user email.
+	DefaultGWSUserEmailSecretName = "IDPSCIM_GWSUserEmail"
+
+	// DefaultAWSSCIMEndpointSecretName is the name of the secret containing the SCIM endpoint.
+	DefaultAWSSCIMEndpointSecretName = "IDPSCIM_SCIMEndpoint"
+
+	// DefaultAWSSCIMAccessTokenSecretName is the name of the secret containing the SCIM access token.
+	DefaultAWSSCIMAccessTokenSecretName = "IDPSCIM_SCIMAccessToken"
 )
 
 // Config represents the configuration of the application.
@@ -40,17 +52,17 @@ type Config struct {
 	LogLevel  string `mapstructure:"log_level" json:"log_level" yaml:"log_level"`
 	LogFormat string `mapstructure:"log_format" json:"log_format" yaml:"log_format"`
 
-	GWSServiceAccountFile          string   `mapstructure:"gws_service_account_file" json:"gws_service_account_file" yaml:"gws_service_account_file"`
-	GWSUserEmail                   string   `mapstructure:"gws_user_email" json:"gws_user_email" yaml:"gws_user_email"`
-	GWSServiceAccountFileSecretARN string   `mapstructure:"gws_service_account_file_secret_arn" json:"gws_service_account_file_secret_arn" yaml:"gws_service_account_file_secret_arn"`
-	GWSUserEmailSecretARN          string   `mapstructure:"gws_user_email_secret_arn" json:"gws_user_email_secret_arn" yaml:"gws_user_email_secret_arn"`
-	GWSGroupsFilter                []string `mapstructure:"gws_groups_filter" json:"gws_groups_filter" yaml:"gws_groups_filter"`
-	GWSUsersFilter                 []string `mapstructure:"gws_users_filter" json:"gws_users_filter" yaml:"gws_users_filter"`
+	GWSServiceAccountFile           string   `mapstructure:"gws_service_account_file" json:"gws_service_account_file" yaml:"gws_service_account_file"`
+	GWSUserEmail                    string   `mapstructure:"gws_user_email" json:"gws_user_email" yaml:"gws_user_email"`
+	GWSServiceAccountFileSecretName string   `mapstructure:"gws_service_account_file_secret_name" json:"gws_service_account_file_secret_name" yaml:"gws_service_account_file_secret_name"`
+	GWSUserEmailSecretName          string   `mapstructure:"gws_user_email_secret_name" json:"gws_user_email_secret_name" yaml:"gws_user_email_secret_name"`
+	GWSGroupsFilter                 []string `mapstructure:"gws_groups_filter" json:"gws_groups_filter" yaml:"gws_groups_filter"`
+	GWSUsersFilter                  []string `mapstructure:"gws_users_filter" json:"gws_users_filter" yaml:"gws_users_filter"`
 
-	AWSSCIMEndpoint             string `mapstructure:"aws_scim_endpoint" json:"aws_scim_endpoint" yaml:"aws_scim_endpoint"`
-	AWSSCIMAccessToken          string `mapstructure:"aws_scim_access_token" json:"aws_scim_access_token" yaml:"aws_scim_access_token"`
-	AWSSCIMEndpointSecretARN    string `mapstructure:"aws_scim_endpoint_secret_arn" json:"aws_scim_endpoint_secret_arn" yaml:"aws_scim_endpoint_secret_arn"`
-	AWSSCIMAccessTokenSecretARN string `mapstructure:"aws_scim_access_token_secret_arn" json:"aws_scim_access_token_secret_arn" yaml:"aws_scim_access_token_secret_arn"`
+	AWSSCIMEndpoint              string `mapstructure:"aws_scim_endpoint" json:"aws_scim_endpoint" yaml:"aws_scim_endpoint"`
+	AWSSCIMAccessToken           string `mapstructure:"aws_scim_access_token" json:"aws_scim_access_token" yaml:"aws_scim_access_token"`
+	AWSSCIMEndpointSecretName    string `mapstructure:"aws_scim_endpoint_secret_name" json:"aws_scim_endpoint_secret_name" yaml:"aws_scim_endpoint_secret_name"`
+	AWSSCIMAccessTokenSecretName string `mapstructure:"aws_scim_access_token_secret_name" json:"aws_scim_access_token_secret_name" yaml:"aws_scim_access_token_secret_name"`
 
 	AWSS3BucketName string `mapstructure:"aws_s3_bucket_name" json:"aws_s3_bucket_name" yaml:"aws_s3_bucket_name"`
 	AWSS3BucketKey  string `mapstructure:"aws_s3_bucket_key" json:"aws_s3_bucket_key" yaml:"aws_s3_bucket_key"`
@@ -64,14 +76,18 @@ type Config struct {
 // New returns a new Config
 func New() Config {
 	return Config{
-		ConfigFile:            DefaultConfigFile,
-		IsLambda:              DefaultIsLambda,
-		Debug:                 DefaultDebug,
-		LogLevel:              DefaultLogLevel,
-		LogFormat:             DefaultLogFormat,
-		GWSServiceAccountFile: DefaultGWSServiceAccountFile,
-		SyncMethod:            DefaultSyncMethod,
-		DisableState:          DefaultDisableState,
-		AWSS3BucketKey:        DefaultAWSS3BucketKey,
+		ConfigFile:                      DefaultConfigFile,
+		IsLambda:                        DefaultIsLambda,
+		Debug:                           DefaultDebug,
+		LogLevel:                        DefaultLogLevel,
+		LogFormat:                       DefaultLogFormat,
+		GWSServiceAccountFile:           DefaultGWSServiceAccountFile,
+		SyncMethod:                      DefaultSyncMethod,
+		DisableState:                    DefaultDisableState,
+		AWSS3BucketKey:                  DefaultAWSS3BucketKey,
+		GWSServiceAccountFileSecretName: DefaultGWSServiceAccountFileSecretName,
+		GWSUserEmailSecretName:          DefaultGWSUserEmailSecretName,
+		AWSSCIMEndpointSecretName:       DefaultAWSSCIMEndpointSecretName,
+		AWSSCIMAccessTokenSecretName:    DefaultAWSSCIMAccessTokenSecretName,
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,4 +19,8 @@ func TestNew(t *testing.T) {
 	assert.Equal(cfg.LogFormat, DefaultLogFormat)
 	assert.Equal(cfg.GWSServiceAccountFile, DefaultGWSServiceAccountFile)
 	assert.Equal(cfg.SyncMethod, DefaultSyncMethod)
+	assert.Equal(cfg.GWSServiceAccountFileSecretName, DefaultGWSServiceAccountFileSecretName)
+	assert.Equal(cfg.GWSUserEmailSecretName, DefaultGWSUserEmailSecretName)
+	assert.Equal(cfg.AWSSCIMEndpointSecretName, DefaultAWSSCIMEndpointSecretName)
+	assert.Equal(cfg.AWSSCIMAccessTokenSecretName, DefaultAWSSCIMAccessTokenSecretName)
 }

--- a/pkg/aws/secretsmanager.go
+++ b/pkg/aws/secretsmanager.go
@@ -40,7 +40,7 @@ func NewSecretsManagerService(svc SecretsManagerClientAPI) (*SecretsManagerServi
 	}, nil
 }
 
-// GetSecretValue returns the secret value for the given secret name.
+// GetSecretValue returns the secret value for the given secret name or arn.
 func (s *SecretsManagerService) GetSecretValue(ctx context.Context, secretKey string) (string, error) {
 	vIn := &secretsmanager.GetSecretValueInput{
 		SecretId:     aws.String(secretKey),

--- a/template.yaml
+++ b/template.yaml
@@ -257,10 +257,10 @@ Resources:
           IDPSCIM_AWS_S3_BUCKET_KEY: !Ref BucketKey
           IDPSCIM_GWS_GROUPS_FILTER: !Ref GWSGroupsFilter
           IDPSCIM_GWS_USERS_FILTER: !Ref GWSUsersFilter
-          IDPSCIM_GWS_USER_EMAIL_SECRET_ARN: !Ref AWSGWSUserEmailSecret
-          IDPSCIM_GWS_SERVICE_ACCOUNT_FILE_SECRET_ARN: !Ref AWSGWSServiceAccountFileSecret
-          IDPSCIM_SCIM_ENDPOINT_SECRET_ARN: !Ref AWSSCIMEndpointSecret
-          IDPSCIM_SCIM_ACCESS_TOKEN_SECRET_ARN: !Ref AWSSCIMAccessTokenSecret
+          IDPSCIM_GWS_USER_EMAIL_SECRET_NAME: !Ref AWSGWSUserEmailSecret
+          IDPSCIM_GWS_SERVICE_ACCOUNT_FILE_SECRET_NAME: !Ref AWSGWSServiceAccountFileSecret
+          IDPSCIM_AWS_SCIM_ENDPOINT_SECRET_NAME: !Ref AWSSCIMEndpointSecret
+          IDPSCIM_AWS_SCIM_ACCESS_TOKEN_SECRET_NAME: !Ref AWSSCIMAccessTokenSecret
       Role: !GetAtt LambdaFunctionRole.Arn
       Events:
         SyncScheduledEvent:


### PR DESCRIPTION
added the default variables for secrets name and fixed the env vars name to get the values from the lambda function