### PR TITLE
Replace response reader after reading body

### DIFF
--- a/pkg/aws/scim.go
+++ b/pkg/aws/scim.go
@@ -488,6 +488,7 @@ func (s *SCIMService) GetUserByUserName(ctx context.Context, userName string) (*
 
 	if resp.StatusCode == http.StatusOK && log.GetLevel() == log.TraceLevel {
 		bodyBytes, er := io.ReadAll(resp.Body)
+		resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		if er != nil {
 			log.Error(er)
 		}


### PR DESCRIPTION
A fix for this issue: https://github.com/slashdevops/idp-scim-sync/issues/92.

Recreate the response reader after reading it for the trace log.

Fix inspired by [this blog post](https://blog.flexicondev.com/read-go-http-request-body-multiple-times).

