### PR TITLE
feat: Use generic Google creds method to support Workload Identity Federation

### DIFF
--- a/pkg/google/google.go
+++ b/pkg/google/google.go
@@ -48,15 +48,15 @@ func NewService(ctx context.Context, userEmail string, serviceAccount []byte, sc
 		return nil, ErrGoogleClientScopeNil
 	}
 
-	config, err := google.JWTConfigFromJSON(serviceAccount, scope...)
+	creds, err := google.CredentialsFromJSONWithParams(ctx, serviceAccount, google.CredentialsParams{
+		Scopes:  scope,
+		Subject: userEmail,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("google: error getting JWT config from Service Account: %v", err)
+		return nil, fmt.Errorf("google: error getting config for Service Account: %v", err)
 	}
 
-	config.Subject = userEmail
-	ts := config.TokenSource(ctx)
-
-	svc, err := admin.NewService(ctx, option.WithTokenSource(ts))
+	svc, err := admin.NewService(ctx, option.WithTokenSource(creds.TokenSource))
 	if err != nil {
 		return nil, fmt.Errorf("google: error creating service: %v", err)
 	}


### PR DESCRIPTION
This switches from using google.JWTConfigFromJSON, which only supports JWT service account credentials. Instead it uses google.CredentialsFromJSONWithParams, which supports a variety of different credentials, including service accounts, gcloud user credentials, and Workflow Identity Federation configurations.

This fixes #66 and allows using Workflow Identity Federation, which allows calling from AWS to GCP without needing to provide a service account private key. This helps avoiding the	need for credential rotation.