### PR TITLE
Allow customisation of additional template fields

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -23,6 +23,7 @@ Metadata:
           - Timeout
           - LogGroupName
           - LogGroupRetentionDays
+          - RoleNameSuffix
       - Label:
           default: "State File - Configuration"
         Parameters:
@@ -249,6 +250,11 @@ Parameters:
       Reference: https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html
     Default: bootstrap
 
+  RoleNameSuffix:
+    Type: String
+    Description: Suffix to apply to IAM to avoid conflicts when multiple stacks are running in the same account
+    Default: ""
+
 Resources:
   LambdaFunction:
     Type: AWS::Serverless::Function
@@ -294,7 +300,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Description: !Sub "This role is used by the Lambda function ${AWS::StackName}"
-      RoleName: !Sub "serverless-idp-scim-sync-${AWS::AccountId}-${AWS::Region}"
+      RoleName: !Sub "serverless-idp-scim-sync-${AWS::AccountId}-${AWS::Region}${RoleNameSuffix}"
       Path: /
       AssumeRolePolicyDocument:
         Statement:
@@ -437,7 +443,7 @@ Resources:
           - Sid: AllowAWSLambdaFunction
             Principal:
               AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/serverless-idp-scim-sync-${AWS::AccountId}-${AWS::Region}"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/serverless-idp-scim-sync-${AWS::AccountId}-${AWS::Region}${RoleNameSuffix}"
             Effect: Allow
             Action:
               - s3:GetObject

--- a/template.yaml
+++ b/template.yaml
@@ -255,13 +255,18 @@ Parameters:
     Description: Suffix to apply to IAM to avoid conflicts when multiple stacks are running in the same account
     Default: ""
 
+  LambdaFunctionName:
+    Type: String
+    Description: Name of the created Lambda function
+    Default: "idp-scim-sync"
+
 Resources:
   LambdaFunction:
     Type: AWS::Serverless::Function
     DependsOn:
       - LambdaFunctionLogGroup
     Properties:
-      FunctionName: idp-scim-sync
+      FunctionName: !Ref LambdaFunctionName
       Description: |
         This Lambda function will sync the AWS SSO groups and users with the Google Workspace directory and it will be triggered by an EventBridge rule.
         Project: https://github.com/slashdevops/idp-scim-sync

--- a/template.yaml
+++ b/template.yaml
@@ -21,6 +21,7 @@ Metadata:
           - ScheduleExpression
           - MemorySize
           - Timeout
+          - LogGroupName
           - LogGroupRetentionDays
       - Label:
           default: "State File - Configuration"
@@ -191,6 +192,11 @@ Parameters:
     Default: 300
     MaxValue: 900
     MinValue: 3
+
+  LogGroupName:
+    Type: String
+    Description: The name of the CloudWatch log group
+    Default: "/aws/lambda/idp-scim-sync"
 
   LogGroupRetentionDays:
     Type: Number
@@ -477,7 +483,7 @@ Resources:
   LambdaFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "/aws/lambda/idp-scim-sync"
+      LogGroupName: !Ref LogGroupName
       RetentionInDays: !Ref LogGroupRetentionDays
 
 Outputs:


### PR DESCRIPTION
We need to run two instances of the sync for different Google accounts. There are naming conflicts when trying to do this with two instances in the same account. I've added some additional parameters that allow us to avoid the conflicts.

* Allow override of the Cloudwatch log group name
* Allow a suffix to be added to the IAM role
* Allow override of the Lambda function name

I'm not committed to doing it in this exact way but I do need some way to customise the mentioned fields. Thanks :)