### PR TITLE
feat(release): sign binaries (SLSA L3) and container images (cosign) — OpenSSF Phase 3

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -67,3 +67,30 @@ jobs:
         run: |
           echo "## Make container-publish" >> $GITHUB_STEP_SUMMARY
           GIT_VERSION=${{ github.ref_name }} make container-publish | tee -a $GITHUB_STEP_SUMMARY
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
+
+      - name: Cosign sign published container manifest (keyless / Sigstore)
+        env:
+          GIT_VERSION: ${{ github.ref_name }}
+          COSIGN_YES: "true"
+        run: |
+          echo "## Cosign sign container manifest" >> $GITHUB_STEP_SUMMARY
+          # Reuse the same GHCR credentials that podman used in the publish step.
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | cosign login ghcr.io --username "${{ github.actor }}" --password-stdin
+          IMAGE="ghcr.io/${{ github.repository }}"
+          # podman manifest inspect → resolve the multi-arch manifest tag we just
+          # pushed to its content digest, then sign by digest. Cosign best-practice:
+          # signing by tag races with subsequent pushes; signing by digest does not.
+          # --recursive covers the manifest and every per-platform image under it.
+          for TAG in "${GIT_VERSION}" "latest"; do
+            DIGEST=$(podman manifest inspect "${IMAGE}:${TAG}" | jq -r '.digest // .manifests[0].digest')
+            if [ -z "${DIGEST}" ] || [ "${DIGEST}" = "null" ]; then
+              echo "::error::Could not resolve digest for ${IMAGE}:${TAG}"
+              exit 1
+            fi
+            cosign sign --recursive "${IMAGE}@${DIGEST}" | tee -a $GITHUB_STEP_SUMMARY
+            echo "**Signed:** \`${IMAGE}@${DIGEST}\` (tag: ${TAG})" >> $GITHUB_STEP_SUMMARY
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -62,6 +64,15 @@ jobs:
       - name: Build Distribution zip Assets
         run: |
           GIT_VERSION=${{ github.ref_name }} make build-dist-zip
+
+      - name: Generate subject hashes for SLSA provenance
+        id: hash
+        run: |
+          cd dist/assets
+          # base64-encode the sha256sum output across all release zip artifacts;
+          # consumed by slsa-github-generator to bind provenance to these subjects.
+          HASHES=$(sha256sum *.zip | base64 -w0)
+          echo "hashes=${HASHES}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Distribution files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -105,6 +116,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             dist/assets/**
+
+  provenance:
+    name: Generate SLSA provenance for release assets
+    needs: [build, create-github-release]
+    permissions:
+      actions: read       # read workflow info for provenance subject
+      id-token: write     # keyless signing via Sigstore Fulcio
+      contents: write     # upload multiple.intoto.jsonl to the release
+    # slsa-github-generator MUST be pinned by tag, not SHA. The SLSA verifier
+    # checks the workflow ref against its own allow-list of signed releases.
+    # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.build.outputs.hashes }}
+      upload-assets: true
 
   aws_sam:
     name: Create and Publish AWS SAM Serverless Application

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,17 @@
 # Security Policy
 
-This project is using [Github CodeQL](https://codeql.github.com/) tool to scan the code vulnerabilities and you can see the report in the pipeline
-[![CodeQL Analysis](https://github.com/slashdevops/idp-scim-sync/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/slashdevops/idp-scim-sync/actions/workflows/codeql.yml)
+This project participates in the [OpenSSF Scorecard](https://github.com/ossf/scorecard) program and ships with several security controls enabled by default:
 
-Since this project is always in development and updated to the last release of `go` and its dependencies, the vulnerabilities are always fixed in the last release, so we will support the last 1 major version and its patches.
+* [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/slashdevops/idp-scim-sync/badge)](https://securityscorecards.dev/viewer/?uri=github.com/slashdevops/idp-scim-sync) — continuous Scorecard analysis (`.github/workflows/scorecard.yml`).
+* [![CodeQL](https://github.com/slashdevops/idp-scim-sync/actions/workflows/codeql.yml/badge.svg)](https://github.com/slashdevops/idp-scim-sync/actions/workflows/codeql.yml) — CodeQL SAST on every push and PR (`.github/workflows/codeql.yml`).
+* `govulncheck` runs in the `Build` workflow and blocks PRs that introduce known Go vulnerabilities.
+* All GitHub Actions are pinned by full commit SHA; container base images are pinned by `@sha256` digest.
+* Release binaries are signed and shipped with SLSA Level 3 provenance (see [Verifying release artifacts](#verifying-release-artifacts) below).
+* Container images published to `ghcr.io/slashdevops/idp-scim-sync` are signed with Cosign keyless (Sigstore).
 
 ## Supported Versions
+
+The project follows the latest Go release line and updates its dependencies on a continuous basis. Only the most recent minor version receives security fixes.
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -21,4 +27,42 @@ Since this project is always in development and updated to the last release of `
 
 ## Reporting a Vulnerability
 
-Use the [Project Issues --> Vulnerability](https://github.com/slashdevops/idp-scim-sync/issues/new/choose) to report it
+Use the [Project Issues → Vulnerability template](https://github.com/slashdevops/idp-scim-sync/issues/new/choose) to report a security issue. For sensitive reports, please use [GitHub's private vulnerability reporting](https://github.com/slashdevops/idp-scim-sync/security/advisories/new) instead of a public issue.
+
+## Verifying release artifacts
+
+Starting with versions released after [PR-3 of the OpenSSF hardening effort](https://github.com/slashdevops/idp-scim-sync/issues?q=label%3Aopenssf), every release ships with a SLSA Level 3 provenance attestation (`multiple.intoto.jsonl`) and container images are signed with Cosign keyless (Sigstore).
+
+### Binary release zips (SLSA provenance)
+
+Download the release zip(s) plus the `multiple.intoto.jsonl` attestation from the same release page, then verify with [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier):
+
+```shell
+# Install slsa-verifier (one-time)
+go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@latest
+
+# From the directory where you downloaded the assets
+slsa-verifier verify-artifact \
+  --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/slashdevops/idp-scim-sync \
+  --source-tag v0.45.0 \
+  idpscim-linux-amd64.zip
+```
+
+A successful run prints `PASSED: SLSA verification passed`.
+
+### Container images (Cosign keyless)
+
+Verify the signature on the published multi-arch manifest:
+
+```shell
+# Install cosign (one-time)
+go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/slashdevops/idp-scim-sync/\.github/workflows/' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  ghcr.io/slashdevops/idp-scim-sync:v0.45.0
+```
+
+Cosign prints the verified signature, certificate, and transparency-log entry.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -4,6 +4,18 @@ This document tracks notable changes, new features, and bug fixes across release
 
 ## Unreleased
 
+### OpenSSF Scorecard Hardening (Phase 3) — Signed releases + SLSA provenance
+
+Closes the **Signed-Releases** Scorecard check (0/10 → 10/10) by adopting two complementary supply-chain primitives:
+
+* **SLSA Level 3 provenance for binary release zips.** A new `provenance` job in `.github/workflows/release.yml` calls the official `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0` reusable workflow. It binds every release zip's `sha256` to a Sigstore-signed in-toto attestation (`multiple.intoto.jsonl`) and uploads it to the GitHub release. Anyone can verify the link between artifact ↔ source ↔ build with [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier).
+* **Cosign keyless signing for container images.** After `podman manifest push`, `.github/workflows/container-image.yml` resolves the multi-arch manifest to its content digest and signs by digest with `cosign sign --recursive` (keyless via Sigstore Fulcio + Rekor). Both the tagged image and `latest` are signed.
+
+Also added a `Verifying release artifacts` section to `SECURITY.md` with copy-pasteable verification commands. Fixed a stale `codeql-analysis.yml` reference in the same file.
+
+> [!NOTE]
+> The `slsa-github-generator` reusable workflow is intentionally pinned by tag (not by SHA). The SLSA verifier validates the workflow ref against its own allow-list of signed releases — SHA-pinning would break verification. This is the only documented exception to the project's SHA-pinning rule.
+
 ### OpenSSF Scorecard Hardening (Phase 2) — Vulnerability remediation
 
 Closed the **Vulnerabilities** Scorecard check (0/10 → 10/10). The previous baseline reported 19 known vulnerabilities, all tracing to two indirect dependencies:


### PR DESCRIPTION
## Summary

Phase 3 of the OpenSSF Scorecard hardening effort. Closes the **Signed-Releases** check (0/10 → 10/10) and lays groundwork toward CII-Best-Practices Silver/Gold (which both require cryptographic release signing).

| Scorecard check | Before | Expected after |
|---|---|---|
| Signed-Releases | 0 / 10 | 10 / 10 (starts counting from the first release cut after merge) |

> [!NOTE]
> The check looks at past releases, so the score will reflect 10/10 only after the *next* tagged release inherits these workflows. The plumbing itself is complete.

## What changed

### 1. SLSA Level 3 provenance for binary release zips

* New `build` job output `hashes = base64(sha256sum *.zip)`.
* New `provenance` job in `.github/workflows/release.yml` calls the official `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0` with `upload-assets: true`.
* It binds every release zip's `sha256` to a single Sigstore-signed in-toto attestation (`multiple.intoto.jsonl`) and uploads it to the GitHub release alongside the zips.
* Verifiable by anyone with [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier).

> [!IMPORTANT]
> The SLSA generator workflow is intentionally pinned **by tag, not SHA**. The SLSA verifier validates the workflow ref against its own allow-list of signed releases; SHA-pinning would break verification. This is the only documented exception to the project's SHA-pinning rule. A comment in `release.yml` and a note in `docs/Whats-New.md` flag this for future readers.

### 2. Cosign keyless signing for container images

* `container-image.yml` now installs `sigstore/cosign-installer@v3.9.2` (SHA-pinned).
* After `podman manifest push`, resolves the multi-arch manifest tag to its content digest via `podman manifest inspect | jq -r '.digest'` and signs **by digest** with `cosign sign --recursive` (atomic vs. racy when signing by tag).
* `--recursive` covers the manifest plus each per-platform image under it.
* Both the tagged image (`vX.Y.Z`) and `latest` are signed.
* Reuses the existing GHCR token via `cosign login` — no new secret required.

### 3. Docs

* `SECURITY.md` — added a **Verifying release artifacts** section with copy-pasteable `slsa-verifier verify-artifact` and `cosign verify` commands. Also fixed a stale `codeql-analysis.yml` badge reference (actual workflow is `codeql.yml`).
* `docs/Whats-New.md` — Phase 3 entry under Unreleased, including the SLSA tag-pinning rationale.

## Verification (manual, post-merge)

The actual signing/provenance generation only runs on tagged release pushes. Plan:

1. Merge this PR.
2. Cut a pre-release tag (e.g. `v0.44.2-rc1`) to exercise the path end-to-end.
3. Confirm the GitHub release contains:
   - All `idpscim-*.zip` and `.sha256` files (existing behavior)
   - `multiple.intoto.jsonl` (new — SLSA provenance)
4. Run the verification commands from `SECURITY.md`; expect \`PASSED: SLSA verification passed\` and a cosign verify with a valid Fulcio cert.
5. Pull the new container image and run `cosign verify ghcr.io/slashdevops/idp-scim-sync:v0.44.2-rc1` with the OIDC issuer matcher.
6. Re-run `scorecard --repo=...` locally and confirm Signed-Releases moves toward 10/10 (will fully tick over once a non-RC release is cut).

## Test plan (CI)

- [ ] `Build` workflow passes on this PR (no behavior change for non-release pushes)
- [ ] `CodeQL` passes
- [ ] `Scorecard analysis` runs without the previous "imposter commit" error (fixed in PR #530)

## Follow-ups

- PR-4: fuzz target + CI job
- PR-5: packaging detector (goreleaser)
- Admin: branch protection on `main`, CII Silver application (this PR unlocks the signing prerequisite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)