### PR TITLE
fix(template): scope Lambda role S3+KMS perms to the state object

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -4,6 +4,26 @@ This document tracks notable changes, new features, and bug fixes across release
 
 ## Unreleased
 
+### IAM least-privilege hardening for the state-file Lambda role
+
+Tightens the Lambda execution role in `template.yaml` so it can only touch the single state object via the single intended path. No behavior change for normal operation; the role is now strictly scoped.
+
+**S3 statement (split in two):**
+
+* `S3ObjectPolicy` — `s3:GetObject*` / `s3:PutObject*` are now scoped to the exact state object (`arn:${Partition}:s3:::<bucket>/<BucketKey>`) instead of `<bucket>/*`.
+* `S3ListBucketPolicy` — `s3:ListBucket` stays on the bucket ARN (required by S3) but is now gated by a `s3:prefix` condition matching `BucketKey`.
+
+**KMS statements (`KMSGetDataPolicy` and `KMSDecryptPolicy`):**
+
+Both now carry the AWS-recommended SSE-KMS scoping conditions:
+
+* `kms:ViaService = s3.<region>.amazonaws.com` — the CMK can only be used through requests S3 forwards on the role's behalf, not via direct `kms:Decrypt` / `kms:Encrypt` calls.
+* `kms:EncryptionContext:aws:s3:arn = arn:${Partition}:s3:::<bucket>/<BucketKey>` — the KMS grant only applies when S3 passes that exact object ARN as encryption context. S3 always populates this context for SSE-KMS objects, so legitimate reads/writes of the state file continue to work; any other object path is rejected by KMS.
+
+These are belt-and-braces additions on top of the existing bucket policy, public-access block, `aws:SecureTransport` deny, and SSE-KMS-with-bucket-key configuration.
+
+References: [AWS docs — kms:ViaService](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-via-service), [AWS docs — SSE-KMS encryption context](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-kms-encryption.html).
+
 ### OpenSSF Scorecard Hardening (Phase 4) — Fuzzing
 
 Closes the **Fuzzing** Scorecard check by adding native Go fuzz targets and a CI workflow that exercises them.

--- a/template.yaml
+++ b/template.yaml
@@ -342,7 +342,7 @@ Resources:
                   - !Ref AWSGWSUserEmailSecret
                   - !Ref AWSSCIMEndpointSecret
                   - !Ref AWSSCIMAccessTokenSecret
-              - Sid: S3Policy
+              - Sid: S3ObjectPolicy
                 Effect: Allow
                 Action:
                   - s3:GetObject
@@ -350,16 +350,28 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                   - s3:PutObjectAcl
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}/${BucketKey}"
+              - Sid: S3ListBucketPolicy
+                Effect: Allow
+                Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub "arn:aws:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}"
-                  - !Sub "arn:aws:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}"
+                Condition:
+                  StringLike:
+                    s3:prefix:
+                      - !Ref BucketKey
               - Sid: KMSGetDataPolicy
                 Effect: Allow
                 Action:
                   - kms:GenerateDataKeyPair
                 Resource:
                   - !GetAtt KMSKey.Arn
+                Condition:
+                  StringEquals:
+                    kms:ViaService: !Sub "s3.${AWS::Region}.amazonaws.com"
+                    kms:EncryptionContext:aws:s3:arn: !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}/${BucketKey}"
               - Sid: KMSDecryptPolicy
                 Effect: Allow
                 Action:
@@ -368,6 +380,10 @@ Resources:
                   - kms:GenerateDataKey
                 Resource:
                   - !GetAtt KMSKey.Arn
+                Condition:
+                  StringEquals:
+                    kms:ViaService: !Sub "s3.${AWS::Region}.amazonaws.com"
+                    kms:EncryptionContext:aws:s3:arn: !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}/${BucketKey}"
 
   AWSGWSServiceAccountFileSecret:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
## Summary

Tightens the Lambda execution role in `template.yaml` so it can only touch the single state object via the single intended path. No behavior change for normal operation; the role is now strictly scoped.

- `S3ObjectPolicy` — `s3:GetObject*` / `s3:PutObject*` are scoped to the exact `<bucket>/<BucketKey>` ARN instead of `<bucket>/*`.
- `S3ListBucketPolicy` — `s3:ListBucket` stays on the bucket ARN (required by S3) but is gated by an `s3:prefix` condition matching `BucketKey`.
- `KMSGetDataPolicy` and `KMSDecryptPolicy` — both now carry `kms:ViaService = s3.<region>.amazonaws.com` and `kms:EncryptionContext:aws:s3:arn` pinned to the state object ARN.

## Context

Partial response to #521. Accepts the single legitimate hardening point from that report: scope KMS usage with `kms:ViaService` + `kms:EncryptionContext:aws:s3:arn`, and scope the role's S3 object actions to the exact state object key. The rest of the report (chained-vulnerability framing, state-file HMAC, removing KMS perms from the role) is rejected — see the response on the issue for details.

Refs:
- [AWS docs — `kms:ViaService` condition key](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-via-service)
- [AWS docs — SSE-KMS encryption context](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-kms-encryption.html) (S3 always passes the object ARN as encryption context, so the new condition is satisfied for legitimate reads/writes)

This is defense in depth on top of the existing controls already in `template.yaml` (bucket policy restricting the principal, public-access block, `aws:SecureTransport` deny, SSE-KMS with bucket-key enabled, `kms:CallerAccount` condition on the key policy).

Release: patch (template-only hardening, no behavior change).

## Test plan

- [x] `make go-fmt` — passes (vet, fmt, mod tidy)
- [x] `make test` — passes
- [x] `make build` — passes
- [x] YAML parses cleanly
- [ ] Deploy to a sandbox account and confirm the Lambda still reads/writes the state object successfully (CFN intrinsics like `kms:ViaService` are only validated at deploy time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)