### PR TITLE
fix(ci): restore multi-arch container builds in release workflow

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -15,6 +15,11 @@ jobs:
   build:
     name: Build and Publish Container Images
     runs-on: ubuntu-latest
+    defaults:
+      # pipefail so `make ... | tee $GITHUB_STEP_SUMMARY` propagates the
+      # upstream make exit code instead of being swallowed by tee's exit 0.
+      run:
+        shell: bash -eo pipefail {0}
     permissions:
       contents: read
       packages: write
@@ -23,10 +28,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Install Podman
+      - name: Install Podman and cross-arch emulation
+        # qemu-user-static + binfmt-support register QEMU user-mode handlers
+        # in /proc/sys/fs/binfmt_misc so podman can RUN steps inside arm64
+        # images on this amd64 runner (the Containerfile's `apk add` step
+        # otherwise dies with "exec /bin/sh: Exec format error").
         run: |
           sudo apt-get update
-          sudo apt-get install -y podman
+          sudo apt-get install -y podman qemu-user-static binfmt-support
 
       - name: Tools and versions
         run: |

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -4,6 +4,19 @@ This document tracks notable changes, new features, and bug fixes across release
 
 ## Unreleased
 
+### CI fix: restore multi-arch container builds in the release workflow
+
+Fixes the `Publish Container Images` job (failing since v0.44.1, surfaced again on the v0.45.0 release as ["Could not resolve digest for ghcr.io/slashdevops/idp-scim-sync:v0.45.0"](https://github.com/slashdevops/idp-scim-sync/actions/runs/26356807875/job/77585211704)).
+
+**Root cause.** When the workflow was migrated from Docker to Podman in `ab22744`, the `docker/setup-qemu-action` step was removed on the assumption that pre-built binaries no longer required cross-compilation. They don't — but every `RUN` line in `Containerfile` (notably `apk add ca-certificates`) still has to execute under the target architecture. On the `amd64` runner, building the `arm64` variant therefore needs QEMU user-mode emulation registered with `binfmt_misc`. Without it, `podman build --platform linux/arm64` died with `exec /bin/sh: Exec format error`, the `arm64` image was never created, `podman manifest add` then failed, no manifest was pushed, and `cosign sign` finally failed with "Could not resolve digest". The two upstream `make` failures were not surfaced as red steps because `make ... | tee $GITHUB_STEP_SUMMARY` runs under bash without `pipefail`, so `tee`'s exit 0 masked the make exit 1.
+
+**Changes in `.github/workflows/container-image.yml`:**
+
+* Install `qemu-user-static` and `binfmt-support` alongside `podman` so the kernel can run arm64 binaries during the build.
+* Set `defaults.run.shell: bash -eo pipefail {0}` at the job level so future `cmd | tee` failures fail the step instead of being silently swallowed.
+
+No code changes; release artifacts and signing flow are unchanged.
+
 ### SCIM members sync — major security & performance improvement (closes [#520](https://github.com/slashdevops/idp-scim-sync/issues/520))
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

Fixes the `Publish Container Images` job in the release workflow, which has been failing since **v0.44.1** and surfaced again on the **v0.45.0** release as ["Could not resolve digest for ghcr.io/slashdevops/idp-scim-sync:v0.45.0"](https://github.com/slashdevops/idp-scim-sync/actions/runs/26356807875/job/77585211704).

## Root cause

When the workflow was migrated from Docker to Podman in [`ab22744`](https://github.com/slashdevops/idp-scim-sync/commit/ab22744131f14ef22451f3ff44debc9f18928ec3) (*"fix: replace Docker with Podman and simplify container image publishing"*), the `docker/setup-qemu-action` step was removed on the assumption that pre-built binaries no longer needed cross-compilation.

They don't — but every `RUN` line in [`Containerfile`](../blob/main/Containerfile) (notably `apk add --no-cache --update ca-certificates`) still executes under the **target** architecture. On the `amd64` runner, building the `arm64` variant therefore needs QEMU user-mode emulation registered with `binfmt_misc`. Without it:

1. `podman build --platform linux/arm64` died with `exec /bin/sh: Exec format error`.
2. No `…-linux-arm64` image was created in local storage.
3. `make container-publish` then failed: `podman manifest add` could not find the arm64 image.
4. No manifest was ever pushed to GHCR.
5. `cosign sign` finally turned the job red with **"Could not resolve digest for ghcr.io/slashdevops/idp-scim-sync:v0.45.0"**.

The two upstream `make` failures were **not** surfaced as red steps because `make ... | tee $GITHUB_STEP_SUMMARY` runs under `bash` without `pipefail`, so `tee`'s exit `0` masked `make`'s exit `1`. That's why the job summary showed `✓ Make container-build`, `✓ Make container-publish`, and only the final `✗ Cosign sign …` step turned red.

## Changes

In `.github/workflows/container-image.yml`:

* Install `qemu-user-static` and `binfmt-support` alongside `podman` so the kernel can execute arm64 binaries during the build.
* Add `defaults.run.shell: bash -eo pipefail {0}` at the job level so future `cmd | tee ...` failures fail the step instead of being silently swallowed.

Plus a `Whats-New.md` entry under **Unreleased**.

No code or release-artifact changes; the multi-arch image set and signing flow are unchanged.

## Test plan

- [ ] PR merges cleanly.
- [ ] On the next tag push, the `Publish Container Images` job:
  - [ ] Builds both `…-linux-amd64` and `…-linux-arm64` images.
  - [ ] Pushes a multi-arch manifest to `ghcr.io/slashdevops/idp-scim-sync:<tag>` and `:latest`.
  - [ ] Successfully resolves the manifest digest and signs it with cosign.
- [ ] (Manual) Re-trigger the `Container Image` workflow via `workflow_dispatch` after merge to validate without a tag.
- [ ] (Recovery, separate action) Re-run / re-publish the v0.45.0 container manifest so the existing release is signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)