### PR TITLE
fix(template): use bucket ARN for SSE-KMS encryption context

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -78,11 +78,11 @@ Tightens the Lambda execution role in `template.yaml` so it can only touch the s
 Both now carry the AWS-recommended SSE-KMS scoping conditions:
 
 * `kms:ViaService = s3.<region>.amazonaws.com` — the CMK can only be used through requests S3 forwards on the role's behalf, not via direct `kms:Decrypt` / `kms:Encrypt` calls.
-* `kms:EncryptionContext:aws:s3:arn = arn:${Partition}:s3:::<bucket>/<BucketKey>` — the KMS grant only applies when S3 passes that exact object ARN as encryption context. S3 always populates this context for SSE-KMS objects, so legitimate reads/writes of the state file continue to work; any other object path is rejected by KMS.
+* `kms:EncryptionContext:aws:s3:arn = arn:${Partition}:s3:::<bucket>` — the KMS grant only applies when S3 passes that exact **bucket** ARN as encryption context. The bucket ARN (not the object ARN) is the correct value here because the state bucket has `BucketKeyEnabled: true`: S3 generates a short-lived bucket-level data key once and derives per-object keys locally from it, so the encryption context S3 forwards to KMS is the bucket ARN. The role can still only reach the single state object through the `S3ObjectPolicy` ARN scoping. See [AWS docs — S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html).
 
 These are belt-and-braces additions on top of the existing bucket policy, public-access block, `aws:SecureTransport` deny, and SSE-KMS-with-bucket-key configuration.
 
-References: [AWS docs — kms:ViaService](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-via-service), [AWS docs — SSE-KMS encryption context](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-kms-encryption.html).
+References: [AWS docs — kms:ViaService](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-via-service), [AWS docs — SSE-KMS encryption context](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-kms-encryption.html), [AWS docs — S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html).
 
 ### OpenSSF Scorecard Hardening (Phase 4) — Fuzzing
 

--- a/template.yaml
+++ b/template.yaml
@@ -371,7 +371,7 @@ Resources:
                 Condition:
                   StringEquals:
                     kms:ViaService: !Sub "s3.${AWS::Region}.amazonaws.com"
-                    kms:EncryptionContext:aws:s3:arn: !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}/${BucketKey}"
+                    kms:EncryptionContext:aws:s3:arn: !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}"
               - Sid: KMSDecryptPolicy
                 Effect: Allow
                 Action:
@@ -383,7 +383,7 @@ Resources:
                 Condition:
                   StringEquals:
                     kms:ViaService: !Sub "s3.${AWS::Region}.amazonaws.com"
-                    kms:EncryptionContext:aws:s3:arn: !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}/${BucketKey}"
+                    kms:EncryptionContext:aws:s3:arn: !Sub "arn:${AWS::Partition}:s3:::${BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}"
 
   AWSGWSServiceAccountFileSecret:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
## Summary

- Fixes a runtime regression introduced by #533 (the IAM least-privilege hardening). Every sync started failing with `AccessDenied … kms:Decrypt … no identity-based policy allows the kms:Decrypt action`.
- Root cause: PR #533 pinned `kms:EncryptionContext:aws:s3:arn` to the **object** ARN, but the state bucket has `BucketKeyEnabled: true`. With Bucket Keys enabled, S3 generates a short-lived bucket-level data key and derives per-object keys locally — the encryption context S3 forwards to KMS is the **bucket** ARN, never the object ARN. The condition therefore never matched, and IAM reports a condition-mismatched `Allow` as "not allowed".
- Fix: both `KMSGetDataPolicy` and `KMSDecryptPolicy` now pin the bucket ARN. The role still cannot reach any other object (the `S3ObjectPolicy` ARN scoping handles that), and `kms:ViaService` still forces all KMS access through S3.
- Also updates `docs/Whats-New.md` to describe the correct behavior and link to the [AWS S3 Bucket Keys docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html).

## Observed error (before this fix)

```
User: arn:aws:sts::<acct>:assumed-role/serverless-idp-scim-sync-<acct>-us-east-1/idp-scim-sync
is not authorized to perform: kms:Decrypt
on resource: arn:aws:kms:us-east-1:<acct>:key/<key-id>
because no identity-based policy allows the kms:Decrypt action
```

## Test plan

- [ ] Redeploy the SAM stack with the patched `template.yaml`.
- [ ] Trigger the Lambda manually (or wait for the scheduled `rate(15 minutes)` invocation) and confirm the sync completes without the `kms:Decrypt` `AccessDenied`.
- [ ] Confirm in CloudTrail that the `kms:Decrypt` call from S3 carries `kms:EncryptionContext:aws:s3:arn = arn:aws:s3:::<bucket>` (bucket ARN, no object suffix) — i.e. the new condition matches what S3 actually sends.
- [ ] Sanity-check that the role still cannot read any other object in the bucket (the object-scoping is enforced by `S3ObjectPolicy`, not the KMS condition).

Refs: #521, #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)